### PR TITLE
Add support for rewriting case expressions

### DIFF
--- a/test/erdos/yield_test.clj
+++ b/test/erdos/yield_test.clj
@@ -72,3 +72,20 @@
             (if (even? i)
               (yield :even)
               (list 1 2 3)))))))
+
+(deftest test-case
+  (is (= '(:default :odd :even :odd :even)
+         (gen-seq
+          (doseq [i (range 5)]
+            (case i
+              1 (yield :odd)
+              2 (list 1 2 3)
+              3 (yield :odd)
+              4 (list 1 2 3)
+              (yield :default))
+            (case i
+              1 (list 1 2 3)
+              2 (yield :even)
+              3 (list 1 2 3)
+              4 (yield :even)
+              (list 1 2 3)))))))

--- a/test/erdos/yield_test.clj
+++ b/test/erdos/yield_test.clj
@@ -30,6 +30,24 @@
             (yield j)
             (yield k))))))
 
+(deftest support-case
+  (is (= '(0 1 2 3 4 5 6)
+         (let [f (fn [x]
+                   (gen-seq
+                    (case x
+                      :one-two-three (do
+                                       (yield 1)
+                                       (yield 2)
+                                       (yield 3))
+                      :four-five-six (do
+                                       (yield 4)
+                                       (yield 5)
+                                       (yield 6))
+                      (yield 0))))]
+           (mapcat f '(:zero
+                       :one-two-three
+                       :four-five-six))))))
+
 (deftest infinite-seq
   (is (= (range 10)
          (take 10


### PR DESCRIPTION
Hi,

I've tried implementing support for yielding from within the clauses
of `case` expressions similarly to how `if` is rewritten. The rewrite
function is a bit complicated because it needs to work with the
special form `case*` (the expansion of the regular `case`).

I've also updated my original implementation to discard the return
values of clauses which have not been rewritten.

Please let me know what you think.